### PR TITLE
chore(cloud-init.sh.tmpl): fix the regular expression to filter out banner

### DIFF
--- a/cloud-init.sh.tmpl
+++ b/cloud-init.sh.tmpl
@@ -159,7 +159,7 @@ provision_duration_ms=$(awk '{print $1*1000}' /proc/uptime)
 send_metrics runner.provision_duration $provision_duration_ms "ms|@1"
 
 IFS=$'\r\n'
-./run.sh | grep -vE "^[ \t|/_\\()\-\',\.]*$"| grep -v 'Self-hosted runner registration' | while read line; do
+./run.sh | grep -vE "^[ \t|/_\\()',\.\-]*$"| grep -v 'Self-hosted runner registration' | while read line; do
 	echo $line
 	if echo $line | grep -q "Running job: "; then
 		start_time_ms=$(date +%s%3N)


### PR DESCRIPTION
The previous fix worked fine on the development machine, but it still didn't work in the VM. This time, the testing was done directly in the VM, and there were no issues.