### PR TITLE
Revert "fix(cloud-init): fix the time unit for runner job duration (#14)"

### DIFF
--- a/cloud-init.sh.tmpl
+++ b/cloud-init.sh.tmpl
@@ -163,10 +163,10 @@ IFS=$'\r\n'
 	echo $line
 	if echo $line | grep -q "Running job: "; then
 		ts=$(echo $line | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}Z')
-		start_time_ms=$(date -u -d "${ts/Z/}" +%s%3N)
+		start_time_ms=$(date -u -d "$ts" +%s)
 	elif echo $line | grep -q "completed with result: "; then
 		ts=$(echo $line | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}Z')
-		job_duration_ms=$(($(date -u -d "${ts/Z/}" +%s%3N)-start_time_ms))
+		job_duration_ms=$(($(date -u -d "$ts" +%s)-start_time_ms))
 		send_metrics jobs.duration $job_duration_ms "ms|@1"
 		send_logs job_duration $job_duration_ms
 	fi


### PR DESCRIPTION
This reverts commit fdc61aced74e3bf65034c66c41bc67d7799b36d4.