### PR TITLE
feat: wire runner VMs to per-host ghcr pull-through cache (GHASR-92)

### DIFF
--- a/cloud-init.sh.tmpl
+++ b/cloud-init.sh.tmpl
@@ -127,9 +127,17 @@ sudo chmod 777 /var/run/docker.sock
 # existing daemon.json rather than clobbering it.
 echo "Configuring ghcr pull-through cache as insecure registry"
 sudo mkdir -p /etc/docker
-existing_daemon=$(cat /etc/docker/daemon.json 2>/dev/null || echo '{}')
-echo "$existing_daemon" | jq '.["insecure-registries"] = ((.["insecure-registries"] // []) + ["registry-ghcr.internal:5556"] | unique)' | sudo tee /etc/docker/daemon.json > /dev/null
-sudo systemctl restart docker
+existing_daemon=$(cat /etc/docker/daemon.json 2>/dev/null)
+# treat missing/empty/invalid json as {} so a bad file can't wipe the config
+if ! echo "$existing_daemon" | jq -e . >/dev/null 2>&1; then
+	existing_daemon='{}'
+fi
+merged_daemon=$(echo "$existing_daemon" | jq '.["insecure-registries"] = ((.["insecure-registries"] // []) + ["registry-ghcr.internal:5556"] | unique)')
+# only overwrite if jq produced valid output, otherwise leave the file untouched
+if [[ -n "$merged_daemon" ]]; then
+	echo "$merged_daemon" | sudo tee /etc/docker/daemon.json > /dev/null
+	sudo systemctl restart docker
+fi
 # socket perms are reset by the restart above
 sudo chmod 777 /var/run/docker.sock
 

--- a/cloud-init.sh.tmpl
+++ b/cloud-init.sh.tmpl
@@ -121,6 +121,18 @@ sudo mount -o remount,defaults,nobarrier / /
 echo "Making docker socket less secure"
 sudo chmod 777 /var/run/docker.sock
 
+# GHASR-92: trust the per-host ghcr pull-through cache. It serves plain HTTP on
+# the internal gateway (registry-ghcr.internal:5556 -> 10.1.0.1, resolved via
+# libvirt DNS), so docker must treat it as an insecure registry. Merge into any
+# existing daemon.json rather than clobbering it.
+echo "Configuring ghcr pull-through cache as insecure registry"
+sudo mkdir -p /etc/docker
+existing_daemon=$(cat /etc/docker/daemon.json 2>/dev/null || echo '{}')
+echo "$existing_daemon" | jq '.["insecure-registries"] = ((.["insecure-registries"] // []) + ["registry-ghcr.internal:5556"] | unique)' | sudo tee /etc/docker/daemon.json > /dev/null
+sudo systemctl restart docker
+# socket perms are reset by the restart above
+sudo chmod 777 /var/run/docker.sock
+
 if [[ ! -z "${DOCKER_USER}" && ! -z "${DOCKER_PASS}" ]]; then
 	echo "Login docker"
 	echo "${DOCKER_PASS}" | docker login --username ${DOCKER_USER} --password-stdin

--- a/provision/main.tf
+++ b/provision/main.tf
@@ -53,9 +53,9 @@ resource "libvirt_network" "kong" {
 
     # GHASR-92: point the ghcr pull-through cache hostname at the host gateway
     # (10.1.0.1). The host runs a registry:2 proxy bound to 10.1.0.1:5556, so
+    # once the fleet-wide vars.GHCR_REGISTRY is set to registry-ghcr.internal:5556,
     # runner VMs pull ghcr images over the internal NAT network instead of
-    # saturating public egress. Flip the CI-side vars.GHCR_REGISTRY back to
-    # ghcr.io to bypass the cache.
+    # saturating public egress. Setting that variable to ghcr.io bypasses the cache.
     hosts {
       hostname = "registry-ghcr.internal"
       ip       = "10.1.0.1"

--- a/provision/main.tf
+++ b/provision/main.tf
@@ -50,6 +50,16 @@ resource "libvirt_network" "kong" {
       hostname = "ports.ubuntu.com"
       ip       = "37.27.33.247"
     }
+
+    # GHASR-92: point the ghcr pull-through cache hostname at the host gateway
+    # (10.1.0.1). The host runs a registry:2 proxy bound to 10.1.0.1:5556, so
+    # runner VMs pull ghcr images over the internal NAT network instead of
+    # saturating public egress. Flip the CI-side vars.GHCR_REGISTRY back to
+    # ghcr.io to bypass the cache.
+    hosts {
+      hostname = "registry-ghcr.internal"
+      ip       = "10.1.0.1"
+    }
   }
 
   addresses = ["10.1.0.0/24", "${var.ipv6_prefix}:1001::/96"]

--- a/provision/setup-new-host.sh
+++ b/provision/setup-new-host.sh
@@ -47,6 +47,11 @@ pushd $REPO_PATH/provision
 $REPO_PATH/provision/apply-changes.sh
 popd
 
+# GHASR-92: the per-host ghcr pull-through cache (bound to 10.1.0.1:5556) is
+# deployed separately from the Kong/docker-pull-cache repo. This repo only wires
+# the runner side: libvirt DNS registry-ghcr.internal -> 10.1.0.1 (provision/main.tf)
+# and the VM insecure-registries entry (cloud-init.sh.tmpl).
+
 # currently not sure about the right approach to make it work under apparmor
 echo 'security_driver ="none"' |sudo tee -a /etc/libvirt/qemu.conf
 


### PR DESCRIPTION
## What

Runner-side wiring for [GHASR-92](https://konghq.atlassian.net/browse/GHASR-92): move ghcr pulls onto each host's **local** pull-through cache (`10.1.0.1:5556`), so runner VMs pull over the internal libvirt NAT network instead of the single central cache whose public egress is saturated.

This repo owns only the runner/VM side. The cache service + deployment live in **Kong/docker-pull-cache**: https://github.com/Kong/docker-pull-cache/pull/1

## Changes

- **`provision/main.tf`** — add a libvirt dnsmasq entry `registry-ghcr.internal → 10.1.0.1` on the `kong` network (same mechanism as the existing `archive.ubuntu.com` entries), so every VM resolves the host-local cache with no per-VM config.
- **`cloud-init.sh.tmpl`** — add `registry-ghcr.internal:5556` to docker `insecure-registries` (HTTP registry with a port ⇒ docker needs this), `jq`-merged into any existing `daemon.json`, then restart docker.
- **`provision/setup-new-host.sh`** — comment pointing at the cache deployment repo.

## Confirmed against production (`self-hosted-runner-2`)

- `virbr0` = `10.1.0.1/24`; datadog-agent already binds here — reusing the same internal gateway IP.
- VM → `10.1.0.1` TCP works (not just the datadog UDP); default route is a single hop to the gateway.
- libvirt DNS already resolves custom hostnames for VMs (verified with `archive.ubuntu.com`).

## Rollout

Per-host canary, one machine at a time. **Do not flip `vars.GHCR_REGISTRY` to `registry-ghcr.internal:5556` until every host runs the cache**, since the variable is fleet-wide.

⚠️ Installing docker on a host sets iptables `FORWARD` policy to DROP and can break VM egress — verify VM outbound connectivity right after installing docker on each host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[GHASR-92]: https://konghq.atlassian.net/browse/GHASR-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ